### PR TITLE
Deploy releases to GitHub from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,16 @@ branches:
     # is pushed. This regex matches semantic versions like v1.2.3-rc4+2016.02.22
     - /^\d+\.\d+\.\d+.*$/
 
+before_deploy: bash ci/before_deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: "TODO: add key"
+  file: $PROJECT_NAME-$TRAVIS_TAG-$TARGET.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
+
 notifications:
   email:
 on_success: never

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,26 @@
+set -ex
+
+build_release() {
+    cargo build --target $TARGET --release --verbose
+}
+
+mk_tarball() {
+    local tmpdir="$(mktemp -d)"
+    local name="$PROJECT_NAME-$TRAVIS_TAG-$TARGET"
+    local release_dir="$tmpdir/$name"
+
+    mkdir -p "$release_dir"
+
+    cp "target/$TARGET/release/podcast" "$release_dir/podcast"
+
+    cd "$tmpdir"
+    tar czf "$TRAVIS_BUILD_DIR/$name.tar.gz" "$name"
+    rm -rf "$tmpdir"
+}
+
+main() {
+    build_release
+    mk_tarball
+}
+
+main


### PR DESCRIPTION
I was looking for a Mac OS binary so I wouldn't have to build the program on every update.

This adds automatic GitHub Release publishing from TravisCI when a tagged version is pushed.

A GitHub personal access token with "repo" permissions is required, and you'd have to generate one for this to work. The TravisCI documentation warns that this token will give write access to all public repositories:

> Warning: the public_repo and repo scopes for GitHub oauth tokens grant write access to all of a user’s (public) repositories. For security, it’s ideal for api_key to have write access limited to only repositories where Travis deploys to GitHub releases. The suggested workaround is to create a machine user — a dummy GitHub account that is granted write access on a per repository basis.

(https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token)

Once a token is generated, it can be encrypted like this:

```
$ travis encrypt $GITHUB_TOKEN -r njaremko/podcast --org
```

The resulting encoded string should be added in place of `TODO: add key` in this code.

Here's an example release:

https://travis-ci.com/teddywing/podcast/builds/121889388
https://github.com/teddywing/podcast/releases/tag/0.12.1-beta