### PR TITLE
Clarify skipping downloads on subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ By default, podcasts are downloaded to `$HOME/Podcasts`, but this folder can be 
 
 How many latest episodes to download when first subscribing to new podcasts can be set in the `$PODCAST/.subscriptions.json` file
 
+Set `auto_download_limit` to `0` to skip downloading when first subscribing.
+
 Downloads can be done a variety of ways:
 
 Individually: `podcast download $podcast_name 4`


### PR DESCRIPTION
I ran into some confusion with this in #15. I updated the documentation so that the next person can figure things out a bit more quickly.